### PR TITLE
Prepare Express server for Vercel serverless deployment

### DIFF
--- a/src/tools/base-tool.js
+++ b/src/tools/base-tool.js
@@ -3,7 +3,7 @@
  */
 
 import axios from 'axios';
-import { CONFIG } from '../config.js';
+import { CONFIG } from '../config/environment.js';
 import { logger, logToolUsage, logError } from '../utils/logger.js';
 
 export class BaseTool {
@@ -25,7 +25,7 @@ export class BaseTool {
       
       const config = {
         method,
-        url: `${CONFIG.BACKEND_URL}${CONFIG.AGENT_API_PREFIX}${endpoint}`,
+        url: `${CONFIG.AGENT_API_URL}${CONFIG.AGENT_API_PREFIX}${endpoint}`,
         headers: {
           'Authorization': `Bearer ${authToken}`,
           'Content-Type': 'application/json',

--- a/src/tools/list-my-sheets.js
+++ b/src/tools/list-my-sheets.js
@@ -4,7 +4,7 @@
  */
 
 import { BaseTool } from './base-tool.js';
-import { CONFIG } from '../config.js';
+import { CONFIG } from '../config/environment.js';
 
 export class ListMySheetsool extends BaseTool {
   constructor() {


### PR DESCRIPTION
## Summary
- adjust the server bootstrap to instantiate once and export the Express app for serverless runtimes
- guard the listener startup so that Vercel can handle the request lifecycle and log initialization in serverless mode
- fix MCP tool imports to use the environment config and AGENT_API_URL so the serverless function boots on Vercel

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e559d14298832ab5743153a8dc260d