### PR TITLE
Stabilize Vercel deployment entrypoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+node_modules/
+logs/
+.DS_Store
+.env
+.vercel
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*

--- a/api/server.js
+++ b/api/server.js
@@ -1,0 +1,3 @@
+import { app } from '../src/server.js';
+
+export default app;

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "nodemon": "^3.0.0"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": "18.x"
   },
   "repository": {
     "type": "git",

--- a/src/server.js
+++ b/src/server.js
@@ -16,7 +16,7 @@ import { logger, logStartup, logRequest, logError, logHealthCheck } from './util
 import { apiKeyAuth } from './auth/api-key-auth.js';
 
 // Import tools (these would be copied from the original implementation)
-import { ListMySheetsool } from './tools/list-my-sheets.js';
+import { ListMySheetsTool } from './tools/list-my-sheets.js';
 import { GetSheetSummaryTool } from './tools/get-sheet-summary.js';
 
 class StandaloneMCPServer {
@@ -30,7 +30,7 @@ class StandaloneMCPServer {
 
     // Initialize tools
     this.tools = new Map([
-      ['list_my_sheets', new ListMySheetsool()],
+      ['list_my_sheets', new ListMySheetsTool()],
       ['get_sheet_summary', new GetSheetSummaryTool()],
     ]);
 
@@ -427,9 +427,26 @@ class StandaloneMCPServer {
   }
 }
 
-// Start server
+// Initialize server instance once so it can be reused across invocations
 const server = new StandaloneMCPServer();
-server.start().catch(error => {
-  logError(error, { context: 'Server initialization' });
-  process.exit(1);
-});
+
+// Detect if we are running in a serverless/Vercel environment
+const isServerless = Boolean(process.env.VERCEL);
+
+if (!isServerless) {
+  server.start().catch(error => {
+    logError(error, { context: 'Server initialization' });
+    process.exit(1);
+  });
+} else {
+  logger.info('MCP Server initialized in serverless mode', {
+    environment: CONFIG.NODE_ENV,
+    agentApiUrl: CONFIG.AGENT_API_URL,
+    tools: Array.from(server.tools.keys())
+  });
+}
+
+// Export Express app for serverless runtimes like Vercel
+export const app = server.app;
+export default server.app;
+

--- a/src/tools/base-tool.js
+++ b/src/tools/base-tool.js
@@ -3,7 +3,7 @@
  */
 
 import axios from 'axios';
-import { CONFIG } from '../config.js';
+import { CONFIG } from '../config/environment.js';
 import { logger, logToolUsage, logError } from '../utils/logger.js';
 
 export class BaseTool {
@@ -25,7 +25,7 @@ export class BaseTool {
       
       const config = {
         method,
-        url: `${CONFIG.BACKEND_URL}${CONFIG.AGENT_API_PREFIX}${endpoint}`,
+        url: `${CONFIG.AGENT_API_URL}${CONFIG.AGENT_API_PREFIX}${endpoint}`,
         headers: {
           'Authorization': `Bearer ${authToken}`,
           'Content-Type': 'application/json',

--- a/src/tools/list-my-sheets.js
+++ b/src/tools/list-my-sheets.js
@@ -4,9 +4,9 @@
  */
 
 import { BaseTool } from './base-tool.js';
-import { CONFIG } from '../config.js';
+import { CONFIG } from '../config/environment.js';
 
-export class ListMySheetsool extends BaseTool {
+export class ListMySheetsTool extends BaseTool {
   constructor() {
     super(
       'list_my_sheets',

--- a/vercel.json
+++ b/vercel.json
@@ -1,19 +1,19 @@
 {
   "version": 2,
   "name": "gastoscompartidos-mcp-server",
-  "builds": [
-    {
-      "src": "src/server.js",
-      "use": "@vercel/node",
-      "config": {
-        "includeFiles": ["src/**", "logs/**"]
-      }
+  "functions": {
+    "api/server.js": {
+      "runtime": "nodejs18.x",
+      "includeFiles": [
+        "src/**",
+        "logs/**"
+      ]
     }
-  ],
+  },
   "routes": [
     {
       "src": "/(.*)",
-      "dest": "src/server.js"
+      "dest": "/api/server.js"
     }
   ],
   "env": {


### PR DESCRIPTION
## Summary
- replace the legacy Vercel `builds` config with a Node 18 function that proxies through a new `api/server.js` entrypoint
- expose the Express app from `api/server.js` and adjust the exported tool class naming so imports resolve cleanly
- pin the Node.js engine to `18.x` and add a `.gitignore` so local dependencies stay out of the repository

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e559d14298832ab5743153a8dc260d